### PR TITLE
Update Vidar_Stealer.yara

### DIFF
--- a/Vidar_Stealer.yara
+++ b/Vidar_Stealer.yara
@@ -10,9 +10,9 @@ rule detect_vidar: Vidar
     strings:
         $s1 = "*wallet*.dat" ascii
 
-        $a1 = "Autofill\\%s_%s.txt" ascii
-        $a2 = "History\\%s_%s.txt" ascii
-        $a3 = "Downloads\\%s_%s.txt" ascii
+        //$a1 = "Autofill\\%s_%s.txt" ascii
+        //$a2 = "History\\%s_%s.txt" ascii
+        //$a3 = "Downloads\\%s_%s.txt" ascii
 
         $b1 = "screenshot.jpg" ascii
         $b2 = "Data\\*.dll" ascii


### PR DESCRIPTION
Updated vidar_stealer rule to remove $a* since they are not used in condition and this throws a rule under execution/compilation.